### PR TITLE
feat(chat): add clear_thinking param

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cerebras_cloud_sdk"
-version = "1.59.0"
+version = "1.60.0"
 description = "The official Python library for the cerebras API"
 dynamic = ["readme"]
 license = "Apache-2.0"

--- a/src/cerebras/cloud/sdk/_version.py
+++ b/src/cerebras/cloud/sdk/_version.py
@@ -1,4 +1,4 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 __title__ = "cerebras.cloud.sdk"
-__version__ = "1.59.0"  # x-release-please-version
+__version__ = "1.60.0"  # x-release-please-version

--- a/src/cerebras/cloud/sdk/resources/chat/completions.py
+++ b/src/cerebras/cloud/sdk/resources/chat/completions.py
@@ -50,6 +50,7 @@ class CompletionsResource(SyncAPIResource):
         *,
         model: str,
         disable_reasoning: Optional[bool] | Omit = omit,
+        clear_thinking: Optional[bool] | Omit = omit,
         frequency_penalty: Optional[float] | Omit = omit,
         logit_bias: Optional[object] | Omit = omit,
         logprobs: Optional[bool] | Omit = omit,
@@ -198,6 +199,7 @@ class CompletionsResource(SyncAPIResource):
                     {
                         "model": model,
                         "disable_reasoning": disable_reasoning,
+                        "clear_thinking": clear_thinking,
                         "frequency_penalty": frequency_penalty,
                         "logit_bias": logit_bias,
                         "logprobs": logprobs,
@@ -261,6 +263,7 @@ class AsyncCompletionsResource(AsyncAPIResource):
         *,
         model: str,
         disable_reasoning: Optional[bool] | Omit = omit,
+        clear_thinking: Optional[bool] | Omit = omit,
         frequency_penalty: Optional[float] | Omit = omit,
         logit_bias: Optional[object] | Omit = omit,
         logprobs: Optional[bool] | Omit = omit,
@@ -409,6 +412,7 @@ class AsyncCompletionsResource(AsyncAPIResource):
                     {
                         "model": model,
                         "disable_reasoning": disable_reasoning,
+                        "clear_thinking": clear_thinking,
                         "frequency_penalty": frequency_penalty,
                         "logit_bias": logit_bias,
                         "logprobs": logprobs,

--- a/src/cerebras/cloud/sdk/types/chat/completion_create_params.py
+++ b/src/cerebras/cloud/sdk/types/chat/completion_create_params.py
@@ -55,6 +55,12 @@ class CompletionCreateParams(TypedDict, total=False):
     If set to True, the model will not use any reasoning in its response.
     """
 
+    clear_thinking: Optional[bool]
+    """Clears the model's reasoning context.
+
+    If set to True, the model will clear its internal reasoning state.
+    """
+
     frequency_penalty: Optional[float]
     """Number between -2.0 and 2.0.
 

--- a/tests/test_clear_thinking_param.py
+++ b/tests/test_clear_thinking_param.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import os
+import json
+
+import httpx
+import pytest
+from respx import MockRouter
+
+from cerebras.cloud.sdk import Cerebras, AsyncCerebras
+
+base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
+
+
+class TestClearThinking:
+    @pytest.mark.respx(base_url=base_url)
+    def test_clear_thinking_is_sent_in_body(self, respx_mock: MockRouter, client: Cerebras) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = json.loads((request.content or b"{}").decode())
+            assert body.get("clear_thinking") is True
+            return httpx.Response(200, json={"error": {"message": "ok"}, "status_code": 200})
+
+        respx_mock.post("/v1/chat/completions").mock(side_effect=handler)
+
+        # This should not be blocked by the SDK and should be serialized into the request body.
+        client.chat.completions.create(model="model", clear_thinking=True)
+
+    @pytest.mark.respx(base_url=base_url)
+    async def test_clear_thinking_is_sent_in_body_async(
+        self, respx_mock: MockRouter, async_client: AsyncCerebras
+    ) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = json.loads((request.content or b"{}").decode())
+            assert body.get("clear_thinking") is True
+            return httpx.Response(200, json={"error": {"message": "ok"}, "status_code": 200})
+
+        respx_mock.post("/v1/chat/completions").mock(side_effect=handler)
+
+        await async_client.chat.completions.create(model="model", clear_thinking=True)


### PR DESCRIPTION
- Adds support for the `clear_thinking` request parameter to chat.completions.create (sync and async), including type coverage in CompletionCreateParams.
- Ensures the parameter is serialized into the outgoing /v1/chat/completions JSON payload when provided.
- Adds a focused unit test that verifies request-body behavior without relying on the Prism/OpenAPI mock schema.
- Bumps the package version to 1.60.0.